### PR TITLE
Fix Swapped Project Names on Landscape Page

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -482,7 +482,7 @@ landscape:
             repo_url: https://github.com/GRAAL-Research/poutyne
             crunchbase: https://www.crunchbase.com/organization/grid-ai
           - item:
-            name: PyTorch Geometric Temporal
+            name: PyTorch Lightning
             description: Pretrain, finetune and deploy AI models on multiple GPUs, TPUs with zero code changes.
             homepage_url: https://lightning.ai/
             logo: lightning.svg


### PR DESCRIPTION
While browsing the Landscape page, I noticed that the names of two projects, “PyTorch Geometric” and “PyTorch Lightning,” were accidentally swapped.

This update corrects the mistake to ensure accurate project representation. Let me know if any further adjustments are needed!